### PR TITLE
Add DT 120 to the variant inc files

### DIFF
--- a/BLHeli_S SiLabs/A.inc
+++ b/BLHeli_S SiLabs/A.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#A_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#A_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#A_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#A_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#A_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#A_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/B.inc
+++ b/BLHeli_S SiLabs/B.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#B_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#B_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#B_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#B_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#B_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#B_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/C.inc
+++ b/BLHeli_S SiLabs/C.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#C_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#C_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#C_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#C_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#C_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#C_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/D.inc
+++ b/BLHeli_S SiLabs/D.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#D_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#D_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#D_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#D_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#D_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#D_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/E.inc
+++ b/BLHeli_S SiLabs/E.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#E_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#E_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#E_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#E_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#E_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#E_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/F.inc
+++ b/BLHeli_S SiLabs/F.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#F_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#F_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#F_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#F_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#F_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#F_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/G.inc
+++ b/BLHeli_S SiLabs/G.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#G_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#G_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#G_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#G_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#G_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#G_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/H.inc
+++ b/BLHeli_S SiLabs/H.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#H_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#H_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#H_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#H_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#H_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#H_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/I.inc
+++ b/BLHeli_S SiLabs/I.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#I_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#I_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#I_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#I_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#I_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#I_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/J.inc
+++ b/BLHeli_S SiLabs/J.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#J_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#J_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#J_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#J_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#J_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#J_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/K.inc
+++ b/BLHeli_S SiLabs/K.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#K_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#K_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#K_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#K_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#K_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#K_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/L.inc
+++ b/BLHeli_S SiLabs/L.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#L_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#L_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#L_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#L_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#L_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#L_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/M.inc
+++ b/BLHeli_S SiLabs/M.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#M_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#M_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#M_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#M_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#M_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#M_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/N.inc
+++ b/BLHeli_S SiLabs/N.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#N_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#N_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#N_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#N_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#N_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#N_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/O.inc
+++ b/BLHeli_S SiLabs/O.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#O_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#O_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#O_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#O_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#O_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#O_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/P.inc
+++ b/BLHeli_S SiLabs/P.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#P_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#P_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#P_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#P_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#P_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#P_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/Q.inc
+++ b/BLHeli_S SiLabs/Q.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#Q_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#Q_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#Q_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#Q_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#Q_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#Q_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/R.inc
+++ b/BLHeli_S SiLabs/R.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#R_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#R_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#R_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#R_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#R_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#R_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/S.inc
+++ b/BLHeli_S SiLabs/S.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#S_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#S_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#S_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#S_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#S_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#S_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/T.inc
+++ b/BLHeli_S SiLabs/T.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#T_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#T_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#T_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#T_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#T_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#T_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/U.inc
+++ b/BLHeli_S SiLabs/U.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#U_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#U_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#U_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#U_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#U_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#U_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)
@@ -539,4 +543,3 @@ Set_LED_3 MACRO
 ENDM
 Clear_LED_3 MACRO
 ENDM
-

--- a/BLHeli_S SiLabs/V.inc
+++ b/BLHeli_S SiLabs/V.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#V_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#V_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#V_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#V_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#V_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#V_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)

--- a/BLHeli_S SiLabs/W.inc
+++ b/BLHeli_S SiLabs/W.inc
@@ -70,6 +70,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#W_L_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#W_L_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#W_L_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B10#"	; Project and MCU tag (16 Bytes)
@@ -99,6 +101,8 @@ ELSEIF FETON_DELAY == 70
 Eep_ESC_Layout:		DB	"#W_H_70#        "
 ELSEIF FETON_DELAY == 90
 Eep_ESC_Layout:		DB	"#W_H_90#        "
+ELSEIF FETON_DELAY == 120
+Eep_ESC_Layout:		DB	"#W_H_120#       "
 ENDIF
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI$EFM8B21#"	; Project and MCU tag (16 Bytes)


### PR DESCRIPTION
Some ESCs require longer dead time than the current max of 90. This
change enables a DT 120 setting.

NB Only the G_H variant has been tested!